### PR TITLE
Add spec and fix string captures

### DIFF
--- a/grammars/build.cson
+++ b/grammars/build.cson
@@ -24,26 +24,26 @@
   'comment':
     'name': 'punctuation.comment.build'
     'match': '#[^\\n]*\\n'
-  'string':
-    'patterns': [
+  string:
+    patterns: [
       {
-        'begin': '"""'
-        'end': '"""'
-        'name': 'string.quoted.triple.build'
+        begin: '"""'
+        end: '"""'
+        name: 'string.quoted.triple.build'
       }
       {
-        'match': '(\')([^\']*)(\')'
-        'captures':
-          '0': 'name': 'punctuation.string.single.begin.build'
-          '1': 'name': 'string.quoted.single.build'
-          '2': 'name': 'punctuation.string.single.end.build'
+        match: '(\')([^\']*)(\')'
+        captures:
+          1: name: 'punctuation.string.single.begin.build'
+          2: name: 'string.quoted.single.build'
+          3: name: 'punctuation.string.single.end.build'
       }
       {
-        'match': '(\")([^\"]*)(\")'
-        'captures':
-          '0': 'name': 'punctuation.string.double.begin.build'
-          '1': 'name': 'string.quoted.double.build'
-          '2': 'name': 'punctuation.string.double.end.build'
+        match: '(\")([^\"]*)(\")'
+        captures:
+          1: name: 'punctuation.string.double.begin.build'
+          2: name: 'string.quoted.double.build'
+          3: name: 'punctuation.string.double.end.build'
       }
     ]
   'number':

--- a/grammars/build.cson
+++ b/grammars/build.cson
@@ -1,29 +1,29 @@
-'scopeName': 'source.build'
-'name': 'BUILD'
-'fileTypes': [
+scopeName: 'source.build'
+name: 'BUILD'
+fileTypes: [
   'BUILD'
   'BUCK'
   'WORKSPACE'
 ]
-'injections':
+injections:
   'source.build':
-    'patterns': [
+    patterns: [
       {
-        'include': '#comment'
+        include: '#comment'
       }
     ]
-'patterns': [
+patterns: [
   {
-    'include': '#assignment'
+    include: '#assignment'
   }
   {
-    'include': '#function'
+    include: '#function'
   }
 ]
-'repository':
-  'comment':
-    'name': 'punctuation.comment.build'
-    'match': '#[^\\n]*\\n'
+repository:
+  comment:
+    name: 'punctuation.comment.build'
+    match: '#[^\\n]*\\n'
   string:
     patterns: [
       {
@@ -46,124 +46,124 @@
           3: name: 'punctuation.string.double.end.build'
       }
     ]
-  'number':
-    'match': '\\d+'
-    'captures':
-      '0': 'name': 'constant.numeric.build'
-  'variable':
-    'match': '\\w+'
-    'captures':
-      '0': 'name': 'variable.other.build'
-  'function':
-    'name': 'meta.function.build'
-    'begin': '(\\w+)\\s*(\\()'
-    'beginCaptures':
-      '1': 'name': 'storage.type.function.build'
-      '2': 'name': 'punctuation.function.parameters.begin.build'
-    'end': '\\)'
-    'endCaptures':
-      '0': 'name': 'punctuation.function.parameters.end.build'
-    'patterns': [
+  number:
+    match: '\\d+'
+    captures:
+      0: name: 'constant.numeric.build'
+  variable:
+    match: '\\w+'
+    captures:
+      0: name: 'variable.other.build'
+  function:
+    name: 'meta.function.build'
+    begin: '(\\w+)\\s*(\\()'
+    beginCaptures:
+      1: name: 'storage.type.function.build'
+      2: name: 'punctuation.function.parameters.begin.build'
+    end: '\\)'
+    endCaptures:
+      0: name: 'punctuation.function.parameters.end.build'
+    patterns: [
       {
-        'include': '#argument'
+        include: '#argument'
       }
     ]
-  'argument':
-    'patterns': [
+  argument:
+    patterns: [
       {
-        'name': 'mata.argument.build'
-        'begin': '(\\w+)\\s*(=)\\s*'
-        'beginCaptures':
-          '1': 'name': 'variable.parameter.build'
-          '2': 'name': 'keyword.operator.assignment.build'
-        'end': ',|\\n'
-        'endCaptures':
-          '0': 'name': 'punctuation.separator.build'
-        'patterns': [
+        name: 'mata.argument.build'
+        begin: '(\\w+)\\s*(=)\\s*'
+        beginCaptures:
+          1: name: 'variable.parameter.build'
+          2: name: 'keyword.operator.assignment.build'
+        end: ',|\\n'
+        endCaptures:
+          0: name: 'punctuation.separator.build'
+        patterns: [
           {
-            'include': '#expression'
+            include: '#expression'
           }
         ]
       }
       {
-        'include': '#expression'
+        include: '#expression'
       }
     ]
-  'assignment':
-    'name': 'meta.assignment.build'
-    'begin': '(\\w+)\\s*(=)\\s*'
-    'beginCaptures':
-      '1': 'name': 'variable.other.build'
-      '2': 'name': 'keyword.operator.assignment.build'
-    'end': '(;|\\n)'
-    'endCaptures':
-      '0': 'name': 'punctuation.statement.end.build'
-    'patterns': [
+  assignment:
+    name: 'meta.assignment.build'
+    begin: '(\\w+)\\s*(=)\\s*'
+    beginCaptures:
+      1: name: 'variable.other.build'
+      2: name: 'keyword.operator.assignment.build'
+    end: '(;|\\n)'
+    endCaptures:
+      0: name: 'punctuation.statement.end.build'
+    patterns: [
       {
-        'include': '#expression'
+        include: '#expression'
       }
     ]
-  'array':
-    'name': 'meta.array.build'
-    'begin': '\\['
-    'beginCaptures':
-      '0': 'name': 'punctuation.array.begin.build'
-    'end': '\\]'
-    'endCaptures':
-      '0': 'name': 'punctuation.array.end.build'
-    'patterns': [
+  array:
+    name: 'meta.array.build'
+    begin: '\\['
+    beginCaptures:
+      0: name: 'punctuation.array.begin.build'
+    end: '\\]'
+    endCaptures:
+      0: name: 'punctuation.array.end.build'
+    patterns: [
       {
-        'include': '#expression'
+        include: '#expression'
       }
       {
-        'match': '\\s*([,])\\s*'
-        'captures':
-          '1': 'name': 'punctuation.separator.build'
-      }
-    ]
-  'dictionary':
-    'name': 'meta.dictionary.build'
-    'begin': '\\{'
-    'beginCaptures':
-      '0': 'name': 'punctuation.dictionary.begin.build'
-    'end': '\\s*\\}'
-    'endCaptures':
-      '0': 'name': 'punctuation.dictionary.end.build'
-    'patterns': [
-      {
-        'include': '#expression'
-      }
-      {
-        'match': '\\s*([,:])\\s*'
-        'captures':
-          '1': 'name': 'punctuation.separator.build'
+        match: '\\s*([,])\\s*'
+        captures:
+          1: name: 'punctuation.separator.build'
       }
     ]
-  'expression':
-    'name': 'meta.expression.build'
-    'contentName': 'meta.expression.build'
-    'patterns': [
+  dictionary:
+    name: 'meta.dictionary.build'
+    begin: '\\{'
+    beginCaptures:
+      0: name: 'punctuation.dictionary.begin.build'
+    end: '\\s*\\}'
+    endCaptures:
+      0: name: 'punctuation.dictionary.end.build'
+    patterns: [
       {
-        'include': '#function'
+        include: '#expression'
       }
       {
-        'include': '#array'
+        match: '\\s*([,:])\\s*'
+        captures:
+          1: name: 'punctuation.separator.build'
+      }
+    ]
+  expression:
+    name: 'meta.expression.build'
+    contentName: 'meta.expression.build'
+    patterns: [
+      {
+        include: '#function'
       }
       {
-        'include': '#dictionary'
+        include: '#array'
       }
       {
-        'include': '#number'
+        include: '#dictionary'
       }
       {
-        'include': '#variable'
+        include: '#number'
       }
       {
-        'include': '#string'
+        include: '#variable'
       }
       {
-        'match': '\\+|\\-|\\%'
-        'captures':
-          '0': 'name': 'operator.build'
+        include: '#string'
+      }
+      {
+        match: '\\+|\\-|\\%'
+        captures:
+          0: name: 'operator.build'
       }
     ]

--- a/grammars/bzl.cson
+++ b/grammars/bzl.cson
@@ -1,8 +1,8 @@
-'scopeName': 'source.bzl'
-'name': 'Skylark'
-'fileTypes': [
+scopeName: 'source.bzl'
+name: 'Skylark'
+fileTypes: [
   'bzl'
 ]
-'patterns': [
-  'include': 'source.python'
+patterns: [
+  include: 'source.python'
 ]

--- a/spec/build-spec.coffee
+++ b/spec/build-spec.coffee
@@ -1,0 +1,20 @@
+describe 'Bazel grammar', ->
+  grammar = null
+
+  beforeEach ->
+    waitsForPromise ->
+      atom.packages.activatePackage('language-bazel')
+
+    runs ->
+      grammar = atom.grammars.grammarForScopeName('source.build')
+
+  it 'parses the grammar', ->
+    expect(grammar).toBeTruthy()
+    expect(grammar.scopeName).toBe 'source.build'
+
+
+  it 'tokenizes strings', ->
+    {tokens} = grammar.tokenizeLine 'var = "foobar"'
+
+    expect(tokens[0]).toEqual value: 'var', scopes: ['source.build', 'meta.assignment.build', 'variable.other.build']
+    expect(tokens[5]).toEqual value: 'foobar', scopes: ['source.build', 'meta.assignment.build', 'string.quoted.double.build']


### PR DESCRIPTION
Some changes:
1. Captures are 1-indexed. The 0th index refers to the match in it's entirety.
2. Add spec to prevent regression.
3. CSON doesn't require quotes around keys. Update only affected part of the file.
